### PR TITLE
Under Rails 3.1.1 and config.assets.initialize_on_precompile = false, tinymce assets are not precompile during rake assets:precompile

### DIFF
--- a/lib/tinymce/railtie.rb
+++ b/lib/tinymce/railtie.rb
@@ -12,13 +12,13 @@ module TinyMCE
       load "tinymce/assets.rake"
     end
     
-    initializer "configure assets" do |app|
+    initializer "configure assets", :group => :all do |app|
       app.config.assets.paths.unshift File.join(asset_root, 'integration')
       app.config.assets.paths.unshift File.join(asset_root, 'vendor')
       app.config.assets.precompile << "tinymce/*"
     end
     
-    initializer "static assets" do |app|
+    initializer "static assets", :group => :all do |app|
       if app.config.serve_static_assets
         app.config.assets.paths.unshift File.join(asset_root, 'precompiled')
       end


### PR DESCRIPTION
I believe this is because of this change in 3.1.1:

"rake assets:precompile loads the application but does not initialize it.

To the app developer, this means configuration add in config/initializers/\* will not be executed.

Plugins developers need to special case their initializers that are meant to be run in the assets group by adding :group => :assets. [José Valim]"

I attached a simple fix to force the initializer to run in all groups.
