### PR TITLE
Bugfix for using different asset_host

### DIFF
--- a/assets/integration/tinymce/preinit.js.erb
+++ b/assets/integration/tinymce/preinit.js.erb
@@ -1,5 +1,5 @@
 window.tinyMCEPreInit = window.tinyMCEPreInit || {
-  base:   '<%= Rails.application.config.assets.prefix %>/tinymce',
+  base:   '<%= Rails.application.config.action_controller.asset_host %>/<%= Rails.application.config.assets.prefix %>/tinymce',
   query:  '<%= TinyMCE::VERSION %>',
   suffix: ''
 };


### PR DESCRIPTION
This simple patch fixes incorrect path to the assets if you have something configured asset_host variable, for example:
  config.action_controller.asset_host = static.myapp.com

Without this fix only /assets (or other config.assets.prefix) will be added to the base url. In example myapp.com/assets instead of static.myapp.com/assets.
