### PR TITLE
Local plugins need to be copied to precompiled assets

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -4,4 +4,8 @@ Rake::Task['assets:precompile:primary'].enhance do
 
   mkdir_p target
   cp_r assets, target
+  %w(app lib vendor).each do |path|
+    assets = Rails.root.join(path, 'assets', 'javascripts', 'tinymce')
+    cp_r assets, target if File.directory? assets
+  end
 end


### PR DESCRIPTION
This is an update to the tinymce precompile task to make sure that any custom tinymce plugins are also copied to the precompiled assets folder.  Otherwise, when you try to use a custom plugin in production you get a 404 when tinymce goes to load the plugin.
