### PR TITLE
Remove the precompile rake tasks

### DIFF
--- a/lib/tasks/tinymce-assets.rake
+++ b/lib/tasks/tinymce-assets.rake
@@ -1,7 +1,0 @@
-Rake::Task['assets:precompile:primary'].enhance do
-  assets = File.expand_path(File.dirname(__FILE__) + "/../../vendor/assets/javascripts/tinymce")
-  target = File.join(Rails.public_path, Rails.application.config.assets.prefix)
-
-  mkdir_p target
-  cp_r assets, target
-end

--- a/lib/tinymce/rails/engine.rb
+++ b/lib/tinymce/rails/engine.rb
@@ -6,7 +6,7 @@ module TinyMCE::Rails
     config.tinymce.base = nil
 
     initializer "precompile", :group => :all do |app|
-      app.config.assets.precompile << "tinymce.js"
+      app.config.assets.precompile += ['tinymce/*', 'tinymce-jquery.js', 'tinymce.js']
     end
 
     initializer "helper" do |app|


### PR DESCRIPTION
And just tell it to precompile the whole file paths. This way it wont break on heroku, or while trying to use an S3 storage system for static assets via asset_sync.

This solves the above issue, but I am unsure if this was really a fix for something I am just not seeing, and if this could just cause other problems.

I hope this helps!
