### PR TITLE
Update Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,8 @@ task :process do
     require 'iconv'
     converter = Iconv.new('UTF-8', 'ISO-8859-1')
     Dir["vendor/assets/javascripts/tinymce/**/*.js"].each do |file|
-      contents = converter.iconv(File.read(file)).force_encoding('UTF-8')
+      contents = converter.iconv(File.read(file))
+      contents = contents.force_encoding('UTF-8') if contents.respond_to?(:force_encoding)
       File.open(file, 'w') { |f| f.write(contents) }
     end
   end


### PR DESCRIPTION
update Rakefile to not fail when using ruby 1.8 where force_encoding is not valid
