### PR TITLE
fix a bug with options hash for helper.tinymce

### DIFF
--- a/lib/tinymce/rails/helper.rb
+++ b/lib/tinymce/rails/helper.rb
@@ -16,25 +16,32 @@ module TinyMCE::Rails
     def tinymce(config=:default, options={})
       javascript_tag { tinymce_javascript(config, options) }
     end
-    
+
     # Returns the JavaScript code required to initialize TinyMCE.
     def tinymce_javascript(config=:default, options={})
       options, config = config, :default if config.is_a?(Hash)
-      
+
+      options = prepare_options_for_all_ruby_versions(options)
+
       base_configuration = TinyMCE::Rails.configuration
-      
+
       if base_configuration.is_a?(MultipleConfiguration)
         base_configuration = base_configuration.fetch(config)
       end
-      
+
       configuration = base_configuration.merge(options)
-      
+
       "tinyMCE.init(#{configuration.options_for_tinymce.to_json});".html_safe
     end
-    
+
     # Includes TinyMCE javascript assets via a script tag.
     def tinymce_assets
       javascript_include_tag "tinymce"
+    end
+
+  private
+    def prepare_options_for_all_ruby_versions(options)
+      options.inject({}){|option,(k,v)| option[k.to_s] = v; option}
     end
   end
 end

--- a/spec/helpers/helper_spec.rb
+++ b/spec/helpers/helper_spec.rb
@@ -7,17 +7,17 @@ module TinyMCE::Rails
         tinymce_assets.should have_selector("script", :type => "text/javascript", :src => "/assets/tinymce.js")
       end
     end
-    
+
     describe "#tinymce" do
       before(:each) do
         TinyMCE::Rails.stub(:configuration).and_return(configuration)
       end
-      
+
       context "single-configuration" do
         let(:configuration) {
           Configuration.new("theme" => "advanced", "plugins" => %w(paste table fullscreen))
         }
-        
+
         it "initializes TinyMCE using global configuration" do
           result = tinymce
           result.should have_selector("script", :type => "text/javascript")
@@ -26,19 +26,24 @@ module TinyMCE::Rails
           result.should include('"plugins":"paste,table,fullscreen"')
           result.should include('});')
         end
-      
+
         it "initializes TinyMCE with passed in options" do
           result = tinymce(:theme => "simple")
           result.should include('"theme":"simple"')
           result.should include('"plugins":"paste,table,fullscreen"')
         end
-      
+
+        it "initializes TinyMCE with passed options and config" do
+          result = tinymce(:simple, :editor_selector => "selector")
+          result.should include '"editor_selector":"selector"'
+        end
+
         it "outputs function strings without quotes" do
           result = tinymce(:oninit => "function() { alert('Hello'); }")
           result.should include('"oninit":function() { alert(\'Hello\'); }')
         end
       end
-      
+
       context "multiple-configuration" do
         let(:configuration) {
           MultipleConfiguration.new(
@@ -46,34 +51,46 @@ module TinyMCE::Rails
             "alternate" => { "skin" => "alternate" }
           )
         }
-        
+
         it "initializes TinyMCE with default configuration" do
           result = tinymce
           result.should include('"theme":"advanced"')
           result.should include('"plugins":"paste,table"')
         end
-        
+
         it "merges passed in options with default configuration" do
           result = tinymce(:theme => "simple")
           result.should include('"theme":"simple"')
           result.should include('"plugins":"paste,table"')
         end
-        
+
         it "initializes TinyMCE with custom configuration" do
           result = tinymce(:alternate)
           result.should include('"skin":"alternate"')
         end
-        
+
         it "merges passed in options with custom configuration" do
           result = tinymce(:alternate, :theme => "simple")
           result.should include('"theme":"simple"')
           result.should include('"skin":"alternate"')
         end
-        
+
         it "raises an error when given an invalid configuration" do
           expect { tinymce(:missing) }.to raise_error(KeyError)
         end
       end
+    end
+
+    describe "prepare_options_for_all_ruby_versions" do
+      let(:options) {
+        {:key => "value"}
+      }
+      let(:modified_options) {
+        {"key" => "value"}
+      }
+      specify { prepare_options_for_all_ruby_versions(options).should == modified_options }
+
+      specify { prepare_options_for_all_ruby_versions(modified_options).should == modified_options }
     end
   end
 end


### PR DESCRIPTION
for ruby 1.8.7 the options-hash have to be prepared
