### PR TITLE
Add support for installing assets of tinymce-rails-langs

### DIFF
--- a/lib/tasks/tinymce-assets.rake
+++ b/lib/tasks/tinymce-assets.rake
@@ -3,9 +3,11 @@ assets_task = Rake::Task.task_defined?('assets:precompile:primary') ? 'assets:pr
 Rake::Task[assets_task].enhance do
   require "tinymce/rails/asset_installer"
   
+  assets = Pathname.new(File.expand_path(File.dirname(__FILE__) + "/../../vendor/assets/javascripts/tinymce"))
+
   config   = Rails.application.config
   target   = File.join(Rails.public_path, config.assets.prefix)
   manifest = config.assets.manifest
   
-  TinyMCE::Rails::AssetInstaller.new(target, manifest).install
+  TinyMCE::Rails::AssetInstaller.new(assets, target, manifest).install
 end

--- a/lib/tinymce/rails/asset_installer.rb
+++ b/lib/tinymce/rails/asset_installer.rb
@@ -3,9 +3,8 @@ require "tinymce/rails/asset_manifest"
 module TinyMCE
   module Rails
     class AssetInstaller
-      ASSETS = Pathname.new(File.expand_path(File.dirname(__FILE__) + "/../../../vendor/assets/javascripts/tinymce"))
-      
-      def initialize(target, manifest_path)
+      def initialize(assets, target, manifest_path)
+        @assets = assets
         @target = target
         @manifest_path = manifest_path || target
       end
@@ -34,7 +33,7 @@ module TinyMCE
       end
       
       def copy_assets
-        FileUtils.cp_r(ASSETS, @target, :preserve => true)
+        FileUtils.cp_r(@assets, @target, :preserve => true)
       end
       
       def append_to_manifest
@@ -44,11 +43,11 @@ module TinyMCE
       end
       
       def asset_files
-        Pathname.glob("#{ASSETS}/**/*").select(&:file?)
+        Pathname.glob("#{@assets}/**/*").select(&:file?)
       end
       
       def logical_path(file)
-        file.relative_path_from(ASSETS.parent).to_s
+        file.relative_path_from(@assets.parent).to_s
       end
       
       def move_asset(src, dest)

--- a/spec/lib/asset_installer_spec.rb
+++ b/spec/lib/asset_installer_spec.rb
@@ -10,12 +10,13 @@ module TinyMCE
         stub_const("TinyMCE::Rails::AssetManifest", stub(:load => manifest))
       end
       
+      let(:assets) { Pathname.new(File.expand_path(File.dirname(__FILE__) + "/../../vendor/assets/javascripts/tinymce")) }
       let(:target) { "/assets" }
       let(:manifest_path) { nil }
       let(:manifest) { stub.as_null_object }
       
       def install
-        AssetInstaller.new(target, manifest_path).install
+        AssetInstaller.new(assets, target, manifest_path).install
       end
       
       it "removes TinyMCE index assets" do
@@ -40,13 +41,13 @@ module TinyMCE
       end
       
       it "copies TinyMCE assets to the target directory" do
-        FileUtils.should_receive(:cp_r).with(AssetInstaller::ASSETS, target, :preserve => true)
+        FileUtils.should_receive(:cp_r).with(assets, target, :preserve => true)
         install
       end
       
       it "adds TinyMCE assets to the manifest" do
-        manifest.should_receive(:append).with("tinymce/tiny_mce.js", AssetInstaller::ASSETS.parent.join("tinymce/tiny_mce.js"))
-        manifest.should_receive(:append).with("tinymce/themes/advanced/editor_template.js", AssetInstaller::ASSETS.parent.join("tinymce/themes/advanced/editor_template.js"))
+        manifest.should_receive(:append).with("tinymce/tiny_mce.js", assets.parent.join("tinymce/tiny_mce.js"))
+        manifest.should_receive(:append).with("tinymce/themes/advanced/editor_template.js", assets.parent.join("tinymce/themes/advanced/editor_template.js"))
         install
       end
       


### PR DESCRIPTION
The problem that assets are deleted by the Capistrano `deploy:assets:clean_expired` task was reported in issue #83 and fixed. However, the same problem also exists in the [tinymce-rails-langs](https://github.com/spohlenz/tinymce-rails-langs) gem.

This pull request tries to add support for installing assets of [tinymce-rails-langs](https://github.com/spohlenz/tinymce-rails-langs). It is done by removeing the `ASSETS` constant and save the path to assets as an instance variable.

That is, the path to assets is provided when initialize an new instance of `AssetInstaller`. Therefore, the rake task in [tinymce-rails-langs](https://github.com/spohlenz/tinymce-rails-langs) can also use it to install assets.

Please have a look to see if this is an appropriate change.

Thanks! :smile: 
