### PR TITLE
Fixes error when asset_host is not a string.

### DIFF
--- a/lib/tinymce/rails/engine.rb
+++ b/lib/tinymce/rails/engine.rb
@@ -1,7 +1,7 @@
 module TinyMCE::Rails
   class Engine < ::Rails::Engine
     config.tinymce = ActiveSupport::OrderedOptions.new
-    
+
     # Set an explicit base path for TinyMCE assets (usually defaults to /assets/tinymce)
     config.tinymce.base = nil
 
@@ -20,20 +20,25 @@ module TinyMCE::Rails
     end
 
     def self.default_base
-      File.join(Rails.application.config.action_controller.asset_host || "",
-                relative_url_root || "",
+      File.join(asset_host || "", relative_url_root || "",
                 Rails.application.config.assets.prefix || "/",
                 "tinymce")
     end
-    
+
     def self.relative_url_root
       config = Rails.application.config
-      
+
       if config.respond_to?(:relative_url_root)
         config.relative_url_root
       else
         # Fallback for Rails 3.1
         config.action_controller.relative_url_root
+      end
+    end
+
+    def self.asset_host
+      unless Rails.application.config.action_controller.asset_host.respond_to?(:call)
+        Rails.application.config.action_controller.asset_host
       end
     end
   end

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -16,11 +16,25 @@ module TinyMCE::Rails
         Rails.application.config.stub(:relative_url_root).and_return "/prefix"
         TinyMCE::Rails::Engine.default_base.should eq "/prefix/assets/tinymce"
       end
-      
-      it "includes the asset host if provided" do
-        Rails.application.config.action_controller.stub(:asset_host).and_return "http://assets.example.com"
-        TinyMCE::Rails::Engine.default_base.should eq "http://assets.example.com/assets/tinymce"
+
+      context "asset_host" do
+
+        context "Asset host as a string" do
+          it "includes the asset host if provided" do
+            Rails.application.config.action_controller.stub(:asset_host).and_return "http://assets.example.com"
+            TinyMCE::Rails::Engine.default_base.should eq "http://assets.example.com/assets/tinymce"
+          end
+        end
+
+        context "Asset host as a proc or object that respond to call" do
+          it "should not use the asset_host because precompile don't know about the request" do
+            Rails.application.config.action_controller.stub(:asset_host).and_return ->(request) { "http://assets.example.com" }
+            TinyMCE::Rails::Engine.default_base.should eq "/assets/tinymce"
+          end
+        end
+
       end
+
     end
   end
 end


### PR DESCRIPTION
Rails' asset_host can be either a string or an object that respond to
`call` (e.g. Proc). There was an error because when it was a Proc it
was trying to concatenate it as a string.

Since at assets:precompile we don't know about the request to pass it
forward to the Proc/Class, the better we can do is probably use the
relative path.
