### PR TITLE
fix for tinyMCE undefined in asynchronous javascript load

### DIFF
--- a/lib/tinymce/rails/helper.rb
+++ b/lib/tinymce/rails/helper.rb
@@ -21,7 +21,13 @@ module TinyMCE::Rails
     
     # Returns the JavaScript code required to initialize TinyMCE.
     def tinymce_javascript(config=:default, options={})
-      "tinyMCE.init(#{tinymce_configuration(config, options).to_javascript});".html_safe
+      "(function() {
+         if (typeof tinyMCE != 'undefined') {
+           tinyMCE.init(#{tinymce_configuration(config, options).to_javascript});
+         } else {
+           setTimeout(arguments.callee, 50);
+         }
+       })();".html_safe
     end
     
     # Returns the TinyMCE configuration object.


### PR DESCRIPTION
Google [PageSpeed](https://developers.google.com/speed/pagespeed/) suggests [non-blocking javascript](https://developers.google.com/speed/docs/insights/BlockingJS) in which html content can complete loading without javascript. But it also means `tinyMCE` may not be defined when it is called in the form. This change fixes this issue.