### PR TITLE
Force evaluation of preinit.js.erb file at first

### DIFF
--- a/app/assets/javascripts/tinymce/preinit.js.erb
+++ b/app/assets/javascripts/tinymce/preinit.js.erb
@@ -1,4 +1,6 @@
-window.tinymce = window.tinymce || {
-  base:   '<%= TinyMCE::Rails::Engine.base %>',
-  suffix: ''
-};
+(function(){
+  window.tinymce = window.tinymce || {
+    base:   '<%= TinyMCE::Rails::Engine.base %>',
+    suffix: ''
+  };
+})();


### PR DESCRIPTION
I tried to use TinyMCE along with Rails deployed to [subdirectory](http://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root).

All should work fine, as it's already supported. `relative_url_root` is [read](https://github.com/spohlenz/tinymce-rails/blob/master/lib/tinymce/rails/engine.rb#L37) and passed to [js](https://github.com/spohlenz/tinymce-rails/blob/master/app/assets/javascripts/tinymce/preinit.js.erb)

But while I was debugging problem, I found out that [here](https://github.com/spohlenz/tinymce-rails/blob/master/app/assets/source/tinymce/tinymce.jquery.js#L3095) `base` has default value `/assets/tinymce`. I though it's caused by wrong order of loading js files, but that's also not the case. It seems that `window.tinymce = ... ` is not evaluated, so I wrapped it into anonymous function call.

EDIT:
Explicitly setting `tinyMCE.baseURL` fixes issue, as mentioned here https://github.com/spohlenz/tinymce-rails/issues/133, but it would be nice not have to do it :smile: 