### PR TITLE
Allow to call helper methods with the module as a receiver.

### DIFF
--- a/lib/tinymce/rails/helper.rb
+++ b/lib/tinymce/rails/helper.rb
@@ -38,7 +38,11 @@ module TinyMCE::Rails
       
       base_configuration.merge(options)
     end
-    
+
+    # Make  helper methods module functions, so could be called with the module
+    # as a receiver
+    module_function :tinymce, :tinymce_javascript, :tinymce_configuration
+
     # Includes TinyMCE javascript assets via a script tag.
     def tinymce_assets
       javascript_include_tag "tinymce"


### PR DESCRIPTION
This is sometimes useful. For example my use case was while integrating with rails_admin. Had to define rails_admin/custom/ui.js.erb:

```
$(document).ready(function() {
  function load_tinymce() {
    <%= TinyMCE::Rails::Helper.tinymce_javascript(:rails_admin) %>
  }

  load_tinymce();
  $(document).on('pjax:complete', load_tinymce);
});
```