### PR TITLE
Fix link for config options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ alternate:
     - table
 ```
 
-See the [TinyMCE 4 Documentation](http://www.tinymce.com/wiki.php/Configuration) for a full list of configuration options.
+See the [TinyMCE 4 Documentation](https://www.tinymce.com/docs/advanced/editor-control-identifiers/) for a full list of configuration options.
 
 
 **3. Include the TinyMCE assets**

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ alternate:
     - table
 ```
 
-See the [TinyMCE 4 Documentation](https://www.tinymce.com/docs/advanced/editor-control-identifiers/) for a full list of configuration options.
+See the [TinyMCE 4 Documentation](https://www.tinymce.com/docs/configure/) for a full list of configuration options.
 
 
 **3. Include the TinyMCE assets**


### PR DESCRIPTION
- seems tinymce updated their site, link was broken
- the old link can be found at http://archive.tinymce.com/wiki.php/Controls if you prefer that option