### PR TITLE
Update Gemfiles to not use pre-release versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5.0.0.rc1'
+gem 'rails', '~> 5.0.0'
 #gem 'rails', '~> 4.2.5'
 #gem 'rails', '~> 4.1.14'
 #gem 'rails', '~> 4.0.13'
@@ -11,7 +11,7 @@ gem 'uglifier'
 
 group :test do
   gem "test-unit",   "~> 3.0"
-  gem "rspec-rails", "~> 3.5.0.beta3"
+  gem "rspec-rails", "~> 3.5.0"
   gem "capybara",    "~> 2.4.4"
 end
 

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '4.2.6'
+gem 'rails', '4.2.7.1'
 gem 'jquery-rails'
 gem 'rake', '< 11'
 

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,12 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'rails', '5.0.0.rc1'
+gem 'rails', '5.0.0.1'
 gem 'jquery-rails'
 gem 'rake', '< 11'
 
 group :test do
   gem "test-unit",   "~> 3.0"
-  gem "rspec-rails", "~> 3.5.0.beta3"
+  gem "rspec-rails", "~> 3.5.0"
   gem "capybara",    "~> 2.4.4"
 end
 


### PR DESCRIPTION
Don't want to be using pre-release versions for tests now that the stable versions are released.