### PR TITLE
Offer an install strategy that does not preserve modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The default method (as of 4.5.2), `compile`, adds the TinyMCE paths to the Sproc
 config.tinymce.install = :compile
 ```
 
-If you experience issues with the `compile` method, you may wish to use the `copy` method instead, which copies the TinyMCE assets directly into `public/assets` and appends the file information into the asset manifest.
+If you experience issues with the `compile` method, you may wish to use the `copy` method instead, which copies the TinyMCE assets directly into `public/assets` and appends the file information into the asset manifest. The `copy_no_preserve` method is also available of you do not wish to or cannot preserve file modes on your filesystem.
 
 ```ruby
 config.tinymce.install = :copy

--- a/lib/tinymce/rails/asset_installer.rb
+++ b/lib/tinymce/rails/asset_installer.rb
@@ -1,6 +1,7 @@
 require "tinymce/rails/asset_manifest"
 
 require "tinymce/rails/asset_installer/copy"
+require "tinymce/rails/asset_installer/copy_no_preserve"
 require "tinymce/rails/asset_installer/compile"
 
 module TinyMCE

--- a/lib/tinymce/rails/asset_installer.rb
+++ b/lib/tinymce/rails/asset_installer.rb
@@ -39,7 +39,7 @@ module TinyMCE
         if strategy.is_a?(Class)
           @strategy = strategy
         else
-          @strategy = self.class.const_get(strategy.to_s.titlecase)
+          @strategy = self.class.const_get(strategy.to_s.classify)
         end
       end
       

--- a/lib/tinymce/rails/asset_installer/copy.rb
+++ b/lib/tinymce/rails/asset_installer/copy.rb
@@ -26,7 +26,7 @@ module TinyMCE
         end
         
         def copy_assets
-          logger.info "Copying assets to #{File.join(target, "tinymce")}"
+          logger.info "Copying assets (preserving modes) to #{File.join(target, "tinymce")}"
           FileUtils.cp_r(assets, target, :preserve => true)
         end
         

--- a/lib/tinymce/rails/asset_installer/copy_no_preserve.rb
+++ b/lib/tinymce/rails/asset_installer/copy_no_preserve.rb
@@ -1,0 +1,14 @@
+require "tinymce/rails/asset_installer/copy"
+
+module TinyMCE
+  module Rails
+    class AssetInstaller
+      class CopyNoPreserve < Copy
+        def copy_assets
+          logger.info "Copying assets (without preserving modes) to #{File.join(target, "tinymce")}"
+          FileUtils.cp_r(assets, target)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/asset_installer_spec.rb
+++ b/spec/lib/asset_installer_spec.rb
@@ -63,8 +63,6 @@ module TinyMCE
           install
         end
 
-
-
         it "adds TinyMCE assets to the manifest" do
           expect(manifest).to receive(:append).with("tinymce/tinymce.js", assets.parent.join("tinymce/tinymce.js"))
           expect(manifest).to receive(:append).with("tinymce/themes/modern/theme.js", assets.parent.join("tinymce/themes/modern/theme.js"))

--- a/spec/lib/asset_installer_spec.rb
+++ b/spec/lib/asset_installer_spec.rb
@@ -45,39 +45,56 @@ module TinyMCE
         end
       end
 
-      describe "copy strategy" do
-        let(:strategy) { :copy }
-
+      shared_examples_for "copy strategies" do
         before(:each) do
           allow(FileUtils).to receive(:cp_r)
           allow(FileUtils).to receive(:mv)
         end
-        
+
         it "removes digests from existing TinyMCE assets in the manifest" do
           digested_asset = "tinymce/langs/es-abcde1234567890.js"
           asset = "tinymce/langs/es.js"
-          
+
           allow(manifest).to receive(:each).and_yield(asset)
           expect(manifest).to receive(:remove_digest).with(asset).and_yield(digested_asset, asset)
           allow(File).to receive(:exists?).and_return(true)
           expect(FileUtils).to receive(:mv).with("/assets/tinymce/langs/es-abcde1234567890.js", "/assets/tinymce/langs/es.js", :force => true)
-          
+
           install
         end
-        
-        it "copies TinyMCE assets to the target directory" do
-          expect(FileUtils).to receive(:cp_r).with(assets, target, :preserve => true)
-          install
-        end
-        
+
+
+
         it "adds TinyMCE assets to the manifest" do
           expect(manifest).to receive(:append).with("tinymce/tinymce.js", assets.parent.join("tinymce/tinymce.js"))
           expect(manifest).to receive(:append).with("tinymce/themes/modern/theme.js", assets.parent.join("tinymce/themes/modern/theme.js"))
           install
         end
-        
+
         it "writes the manifest" do
           expect(manifest).to receive(:write)
+          install
+        end
+      end
+
+      describe "copy strategy" do
+        let(:strategy) { :copy }
+
+        it_behaves_like "copy strategies"
+
+        it "copies TinyMCE assets to the target directory" do
+          expect(FileUtils).to receive(:cp_r).with(assets, target, :preserve => true)
+          install
+        end
+      end
+
+      describe "copy_no_preserve strategy" do
+        let(:strategy) { :copy_no_preserve }
+
+        it_behaves_like "copy strategies"
+
+        it "copies TinyMCE assets to the target directory without preserving file modes" do
+          expect(FileUtils).to receive(:cp_r).with(assets, target)
           install
         end
       end


### PR DESCRIPTION
When compiling assets as different users (on a typical Linux file
system), the `preserve` flag used in the Copy strategy can throw
permission errors as it tries to preserve file mode/timestamp
information. This `copy_no_preserve` strategy offers an alternative. It
may be better to simply remove the flag, but this approach offers a choice.