### PR TITLE
Asset pipeline support for tinymce content_css option

### DIFF
--- a/lib/tinymce/rails/configuration.rb
+++ b/lib/tinymce/rails/configuration.rb
@@ -40,6 +40,16 @@ module TinyMCE::Rails
       "spellchecker_languages"        => COMMA
     }
 
+    OPTION_TRANSFORMERS = {
+      # Check for files provided in the content_css option to replace them with their actual path.
+      # If no corresponding stylesheet is found for a file, it will remain unchanged.
+      "content_css" => -> (value) {
+        value.split(OPTION_SEPARATORS["content_css"]).map do |file|
+          ActionController::Base.helpers.stylesheet_path(file.strip) || file
+        end.join(OPTION_SEPARATORS["content_css"])
+      }
+    }
+
     attr_reader :options
 
     def initialize(options)
@@ -62,6 +72,10 @@ module TinyMCE::Rails
           result[key] = Function.new(value)
         else
           result[key] = value
+        end
+
+        if OPTION_TRANSFORMERS[key]
+          result[key] = OPTION_TRANSFORMERS[key].call result[key]
         end
       end
 

--- a/lib/tinymce/rails/configuration.rb
+++ b/lib/tinymce/rails/configuration.rb
@@ -43,7 +43,7 @@ module TinyMCE::Rails
     OPTION_TRANSFORMERS = {
       # Check for files provided in the content_css option to replace them with their actual path.
       # If no corresponding stylesheet is found for a file, it will remain unchanged.
-      "content_css" => -> (value) {
+      "content_css" => ->(value) {
         value.split(OPTION_SEPARATORS["content_css"]).map do |file|
           ActionController::Base.helpers.stylesheet_path(file.strip) || file
         end.join(OPTION_SEPARATORS["content_css"])

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -47,6 +47,22 @@ module TinyMCE::Rails
         config = Configuration.new("oninit" => "function() {}")
         expect(config.options_for_tinymce["oninit"]).to be_a(Configuration::Function)
       end
+
+      it "converts content_css values to asset paths (when passed as comma-separated string)" do
+        config = Configuration.new("content_css" => "editor1.css, editor2.css,missing.css")
+        expect(ActionController::Base.helpers).to receive(:stylesheet_path).with("editor1.css").and_return("/assets/editor1-1234.css")
+        expect(ActionController::Base.helpers).to receive(:stylesheet_path).with("editor2.css").and_return("/assets/editor2-1234.css")
+        expect(ActionController::Base.helpers).to receive(:stylesheet_path).with("missing.css").and_return(nil)
+        expect(config.options_for_tinymce["content_css"]).to eq("/assets/editor1-1234.css,/assets/editor2-1234.css,missing.css")
+      end
+
+      it "converts content_css values to asset paths (when passed as array)" do
+        config = Configuration.new("content_css" => ["editor1.css", "editor2.css", "missing.css"])
+        expect(ActionController::Base.helpers).to receive(:stylesheet_path).with("editor1.css").and_return("/assets/editor1-1234.css")
+        expect(ActionController::Base.helpers).to receive(:stylesheet_path).with("editor2.css").and_return("/assets/editor2-1234.css")
+        expect(ActionController::Base.helpers).to receive(:stylesheet_path).with("missing.css").and_return(nil)
+        expect(config.options_for_tinymce["content_css"]).to eq("/assets/editor1-1234.css,/assets/editor2-1234.css,missing.css")
+      end
     end
 
     describe "#merge" do


### PR DESCRIPTION
The configuration class got an `OPTION_TRANSFORMERS` constant which purpose is to transform options when calling `options_for_tinymce`.

The `content_css` transformer split the value with commas ([TinyMCE content_css](https://www.tinymce.com/docs-3x/reference/configuration/Configuration3x@content_css/)), then for each file, it look for an existing stylesheet in the asset pipeline. If a such stylesheet exists, it replace the path with the corresponding path generated by the asset pipeline, if not, the path remains unchanged. The value is then joined again with commas.

With this feature, we are able to do things like this:

```yaml
# config/tinymce.yml
content_css: reset.css, application.css
```

And then get a configuration like this:

```html
<script>
  // Using the tinymce_configuration helper
  var tinymceOptions = {
    content_css: '/assets/reset.self-b7133ed7c815140f95153cf7e6986f33fdb2e8235138031a856bc8a6d7f31193.css?body=1,/assets/application.self-c1c3ac386bde898b4c2c58fcd54fce97ab512972ba5fe65b5d87342e50dd6dd7.css?body=1'
  }
</script>
```

### Option transformers:
```ruby
OPTION_TRANSFORMERS = {
  # Check for files provided in the content_css option to replace them with their actual path.
  # If no corresponding stylesheet is found for a file, it will remain unchanged.
  "content_css" => -> (value) {
    value.split(OPTION_SEPARATORS["content_css"]).map do |file|
      ActionController::Base.helpers.stylesheet_path(file.strip) || file
    end.join(OPTION_SEPARATORS["content_css"])
  }
}
```

### options_for_tinymce method:
```ruby
def options_for_tinymce
  result = {}

  options.each do |key, value|
    if OPTION_SEPARATORS[key] && value.is_a?(Array)
      result[key] = value.join(OPTION_SEPARATORS[key])
    elsif value.to_s.starts_with?("function(")
      result[key] = Function.new(value)
    else
      result[key] = value
    end

    if OPTION_TRANSFORMERS[key]
      result[key] = OPTION_TRANSFORMERS[key].call result[key]
    end
  end

  result
end
```