### PR TITLE
Fix when tinymce-rails-langs assets conflicted with tinymce-rails-imageupload assets

### DIFF
--- a/lib/tinymce/rails/asset_installer/copy.rb
+++ b/lib/tinymce/rails/asset_installer/copy.rb
@@ -39,6 +39,8 @@ module TinyMCE
         def move_asset(src, dest)
           with_asset(src, dest) do |src, dest|
             logger.info "Removing digest from #{src}"
+
+            FileUtils.rm dest if File.exists?(dest)
             FileUtils.mv(src, dest, :force => true)
           end
         end

--- a/spec/lib/asset_installer_spec.rb
+++ b/spec/lib/asset_installer_spec.rb
@@ -49,6 +49,7 @@ module TinyMCE
         before(:each) do
           allow(FileUtils).to receive(:cp_r)
           allow(FileUtils).to receive(:mv)
+          allow(FileUtils).to receive(:rm)
         end
 
         it "removes digests from existing TinyMCE assets in the manifest" do


### PR DESCRIPTION
When in project installed both gems tinymce-rails-langs and tinymce-rails-imageupload assets compiling with exception:
```
ArgumentError: same file: .../releases/20180213063815/public/assets/tinymce/plugins/uploadimage/langs/de-58e6b2b476b85cf7b8e8cc4251560977.js and .../releases/20180213063815/public/assets/tinymce/plugins/uploadimage/langs/de.js
```

It's happened because lang file already exists in assets folder. I'm check files and skipping move if files equal.