### PR TITLE
Allow for relative paths in content_css configuration

### DIFF
--- a/lib/tinymce/rails/configuration.rb
+++ b/lib/tinymce/rails/configuration.rb
@@ -14,6 +14,8 @@ module TinyMCE::Rails
       }
     end
 
+    RELATIVE_PATH_REGEX = /^(\/|\.{1,2})\S*/
+
     COMMA = ",".freeze
     SPACE = " ".freeze
     SEMICOLON = ";".freeze
@@ -45,7 +47,9 @@ module TinyMCE::Rails
       # If no corresponding stylesheet is found for a file, it will remain unchanged.
       "content_css" => ->(value) {
         value.split(OPTION_SEPARATORS["content_css"]).map do |file|
-          ActionController::Base.helpers.stylesheet_path(file.strip) || file
+          RELATIVE_PATH_REGEX.match(file) ||
+            ActionController::Base.helpers.stylesheet_path(file.strip) ||
+            file
         end.join(OPTION_SEPARATORS["content_css"])
       }
     }

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -48,6 +48,24 @@ module TinyMCE::Rails
         expect(config.options_for_tinymce["oninit"]).to be_a(Configuration::Function)
       end
 
+      it "does not convert relative content_css values to asset paths" do
+        config = Configuration.new("content_css" => "./relative_styles.css")
+        expect(ActionController::Base.helpers).to_not receive(:stylesheet_path)
+        expect(config.options_for_tinymce["content_css"]).to eq("./relative_styles.css")
+      end
+
+      it "does not convert relative content_css values to asset paths (when passed as comma-separated string)" do
+        config = Configuration.new("content_css" => "/layout.css,./custom1.css,../custom2.css")
+        expect(ActionController::Base.helpers).to_not receive(:stylesheet_path)
+        expect(config.options_for_tinymce["content_css"]).to eq("/layout.css,./custom1.css,../custom2.css")
+      end
+
+      it "does not convert relative content_css values to asset paths (when passed as array)" do
+        config = Configuration.new("content_css" => ["/layout.css", "./custom1.css", "../custom2.css"])
+        expect(ActionController::Base.helpers).to_not receive(:stylesheet_path)
+        expect(config.options_for_tinymce["content_css"]).to eq("/layout.css,./custom1.css,../custom2.css")
+      end
+
       it "converts content_css values to asset paths (when passed as comma-separated string)" do
         config = Configuration.new("content_css" => "editor1.css, editor2.css,missing.css")
         expect(ActionController::Base.helpers).to receive(:stylesheet_path).with("editor1.css").and_return("/assets/editor1-1234.css")


### PR DESCRIPTION
TinyMCE allows for [relative urls for content_css](https://www.tinymce.com/docs/configure/content-appearance/#content_css), however the current transformer first checks with `ActionController::Base` to find the path for the given file, which can raise an error when the path given starts with `.` or `..` (seen on Rails `4.2.10` - though the error itself gets raised further down in [`sprockets`](https://github.com/rails/sprockets/blob/3.x/lib/sprockets/path_utils.rb#L113)).

```ruby
> ActionController::Base.helpers.stylesheet_path('content_css')
=> "/stylesheets/content_css.css"
> ActionController::Base.helpers.stylesheet_path('/content_css')
=> "/content_css.css"
> ActionController::Base.helpers.stylesheet_path('./content_css')
NoMethodError: undefined method `start_with?' for nil:NilClass
> ActionController::Base.helpers.stylesheet_path('../content_css')
NoMethodError: undefined method `start_with?' for nil:NilClass
```

This adds an additional check the transformer for paths starting with `/`, `.`, and `..`, and passes that through to the `tinymce` configuration before going through the rails/sprockets pipeline. This mirrors how other configurations (ex. `image_list` or `images_upload_url`) pass a given path to `TinyMCE`.

This would allow an app to configure the editor to retrieve `css` from an endpoint relative to where the editor itself loads - such as stylesheets managed by users for a CMS, for example.