### PR TITLE
Fix bug with external asset host

### DIFF
--- a/lib/tinymce/rails/engine.rb
+++ b/lib/tinymce/rails/engine.rb
@@ -61,7 +61,7 @@ module TinyMCE::Rails
     end
 
     def self.normalize_host(host)
-      if host =~ /^https?:\/\// || host =~ /^\/\//
+      if (host =~ /^https?:\/\//).present? || (host =~ /^\/\//).present?
         host
       else
         # Use a protocol-relative URL if not otherwise specified


### PR DESCRIPTION
The first line of the conditional in the normalize_host function will always return false because if the regular expression matches it will return 0 which evaluates to false. This pull request fixes the issue by using the present? method which will reliably evaluate to true when the regex matches.