### PR TITLE
File.exists? is deprecated

### DIFF
--- a/lib/tinymce/rails/asset_installer.rb
+++ b/lib/tinymce/rails/asset_installer.rb
@@ -56,7 +56,7 @@ module TinyMCE
           src = File.join(@target, src)
           dest = File.join(@target, dest)
 
-          yield src, dest if File.exists?(src)
+          yield src, dest if File.exist?(src)
         end
       end
     end

--- a/lib/tinymce/rails/asset_installer/compile.rb
+++ b/lib/tinymce/rails/asset_installer/compile.rb
@@ -24,14 +24,14 @@ module TinyMCE
         def symlink_asset(src, dest)
           with_asset(src, dest) do |src, dest|
             create_symlink(src, dest)
-            create_symlink("#{src}.gz", "#{dest}.gz") if File.exists?("#{src}.gz")
+            create_symlink("#{src}.gz", "#{dest}.gz") if File.exist?("#{src}.gz")
           end
         end
 
         def create_symlink(src, dest)
           target = File.basename(src)
 
-          unless File.exists?(dest) && File.symlink?(dest) && File.readlink(dest) == target
+          unless File.exist?(dest) && File.symlink?(dest) && File.readlink(dest) == target
             logger.info "Creating symlink #{dest}"
             FileUtils.ln_s(target, dest, :force => true)
           else

--- a/lib/tinymce/rails/asset_manifest.rb
+++ b/lib/tinymce/rails/asset_manifest.rb
@@ -37,7 +37,7 @@ module TinyMCE
     class YamlManifest < AssetManifest
       def self.try(manifest_path)
         yaml_file = File.join(manifest_path, "manifest.yml")
-        new(yaml_file) if File.exists?(yaml_file)
+        new(yaml_file) if File.exist?(yaml_file)
       end
 
       def initialize(file)

--- a/lib/tinymce/rails/configuration_file.rb
+++ b/lib/tinymce/rails/configuration_file.rb
@@ -25,13 +25,13 @@ module TinyMCE::Rails
     end
 
     def last_updated
-      File.exists?(path) && File.mtime(path)
+      File.exist?(path) && File.mtime(path)
     end
 
     def load_configuration
       @last_loaded = last_updated
 
-      return Configuration.new_with_defaults if !File.exists?(path)
+      return Configuration.new_with_defaults if !File.exist?(path)
 
       options = load_yaml(path)
 

--- a/spec/lib/asset_installer_spec.rb
+++ b/spec/lib/asset_installer_spec.rb
@@ -37,7 +37,7 @@ module TinyMCE
           allow(manifest).to receive(:each).and_yield(asset)
           expect(manifest).to receive(:asset_path).with(asset).and_yield(digested_asset, asset)
 
-          allow(File).to receive(:exists?).and_return(true)
+          allow(File).to receive(:exist?).and_return(true)
 
           expect(FileUtils).to receive(:ln_s).with("es-abcde1234567890.js", "/assets/tinymce/langs/es.js", :force => true)
 
@@ -58,7 +58,7 @@ module TinyMCE
 
           allow(manifest).to receive(:each).and_yield(asset)
           expect(manifest).to receive(:remove_digest).with(asset).and_yield(digested_asset, asset)
-          allow(File).to receive(:exists?).and_return(true)
+          allow(File).to receive(:existWW?).and_return(true)
           expect(FileUtils).to receive(:mv).with("/assets/tinymce/langs/es-abcde1234567890.js", "/assets/tinymce/langs/es.js", :force => true)
 
           install

--- a/spec/lib/asset_installer_spec.rb
+++ b/spec/lib/asset_installer_spec.rb
@@ -58,7 +58,7 @@ module TinyMCE
 
           allow(manifest).to receive(:each).and_yield(asset)
           expect(manifest).to receive(:remove_digest).with(asset).and_yield(digested_asset, asset)
-          allow(File).to receive(:existWW?).and_return(true)
+          allow(File).to receive(:exist?).and_return(true)
           expect(FileUtils).to receive(:mv).with("/assets/tinymce/langs/es-abcde1234567890.js", "/assets/tinymce/langs/es.js", :force => true)
 
           install

--- a/spec/lib/configuration_file_spec.rb
+++ b/spec/lib/configuration_file_spec.rb
@@ -50,7 +50,7 @@ module TinyMCE::Rails
       end
 
       it "returns true if the file no longer exists" do
-        allow(File).to receive(:exists?).and_return(false)
+        allow(File).to receive(:exist∑?).and_return(false)
         expect(file).to be_changed
       end
 

--- a/spec/lib/configuration_file_spec.rb
+++ b/spec/lib/configuration_file_spec.rb
@@ -50,7 +50,7 @@ module TinyMCE::Rails
       end
 
       it "returns true if the file no longer exists" do
-        allow(File).to receive(:exist∑?).and_return(false)
+        allow(File).to receive(:exist?).and_return(false)
         expect(file).to be_changed
       end
 


### PR DESCRIPTION
```
tinymce-rails-5.10.2/lib/tinymce/rails/configuration_file.rb:28: warning: File.exists? is deprecated; use File.exist? instead
```

This PR uses File.exist? instead of deprecated function call.