### PR TITLE
Add back missing Sprockets 4 manifest file

### DIFF
--- a/vendor/assets/config/tinymce-rails.manifest.js
+++ b/vendor/assets/config/tinymce-rails.manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../javascripts/tinymce .js
+//= link_tree ../javascripts/tinymce .css
+//= link_tree ../javascripts/tinymce .woff


### PR DESCRIPTION
This file got removed by accident in
e05c0ff5a562f8758b3c1747370bec9023e8c4d8 as part of the wholesale
vendored assets update to TinyMCE 6.0.2.

Without this manifest the vendored code is not precompiled and
consequently cannot be used in production.