### PR TITLE
Update deprecated usage of File.exists? to File.exist?

### DIFF
--- a/lib/tinymce/rails/asset_installer.rb
+++ b/lib/tinymce/rails/asset_installer.rb
@@ -56,7 +56,7 @@ module TinyMCE
           src = File.join(@target, src)
           dest = File.join(@target, dest)
 
-          yield src, dest if File.exists?(src)
+          yield src, dest if File.exist?(src)
         end
       end
     end

--- a/lib/tinymce/rails/asset_installer/compile.rb
+++ b/lib/tinymce/rails/asset_installer/compile.rb
@@ -24,14 +24,14 @@ module TinyMCE
         def symlink_asset(src, dest)
           with_asset(src, dest) do |src, dest|
             create_symlink(src, dest)
-            create_symlink("#{src}.gz", "#{dest}.gz") if File.exists?("#{src}.gz")
+            create_symlink("#{src}.gz", "#{dest}.gz") if File.exist?("#{src}.gz")
           end
         end
 
         def create_symlink(src, dest)
           target = File.basename(src)
 
-          unless File.exists?(dest) && File.symlink?(dest) && File.readlink(dest) == target
+          unless File.exist?(dest) && File.symlink?(dest) && File.readlink(dest) == target
             logger.info "Creating symlink #{dest}"
             FileUtils.ln_s(target, dest, :force => true)
           else

--- a/lib/tinymce/rails/asset_manifest.rb
+++ b/lib/tinymce/rails/asset_manifest.rb
@@ -37,7 +37,7 @@ module TinyMCE
     class YamlManifest < AssetManifest
       def self.try(manifest_path)
         yaml_file = File.join(manifest_path, "manifest.yml")
-        new(yaml_file) if File.exists?(yaml_file)
+        new(yaml_file) if File.exist?(yaml_file)
       end
 
       def initialize(file)

--- a/lib/tinymce/rails/configuration_file.rb
+++ b/lib/tinymce/rails/configuration_file.rb
@@ -25,13 +25,13 @@ module TinyMCE::Rails
     end
 
     def last_updated
-      File.exists?(path) && File.mtime(path)
+      File.exist?(path) && File.mtime(path)
     end
 
     def load_configuration
       @last_loaded = last_updated
 
-      return Configuration.new_with_defaults if !File.exists?(path)
+      return Configuration.new_with_defaults if !File.exist?(path)
 
       options = load_yaml(path)
 


### PR DESCRIPTION
This enables TinyMCE v4 users to use the newly released Ruby 3.2.0 where File.exists [has been removed](https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2).