### PR TITLE
Support Psych 4.0+ on tinymce 5 (#288)

### DIFF
--- a/lib/tinymce/rails/configuration_file.rb
+++ b/lib/tinymce/rails/configuration_file.rb
@@ -43,7 +43,8 @@ module TinyMCE::Rails
     end
 
     def load_yaml(path)
-      YAML::load(ERB.new(IO.read(path)).result)
+      result = ERB.new(IO.read(path)).result
+      YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(result) : YAML.load(result)
     end
   end
 end


### PR DESCRIPTION
Starting with Psych 4.0 the load function has been changed to be safe_load instead of unsafe_load.

Apply PR #288 on tinymce-5 branch