### PR TITLE
Only include vendored assets in the gem

### DIFF
--- a/tinymce-rails.gemspec
+++ b/tinymce-rails.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version = TinyMCE::Rails::VERSION
   s.summary = "Rails asset pipeline integration for TinyMCE."
   s.description = "Seamlessly integrates TinyMCE into the Rails asset pipeline introduced in Rails 3.1."
-  s.files = Dir["README.md", "LICENSE", "Rakefile", "app/**/*", "lib/**/*", "vendor/**/*"]
+  s.files = Dir["README.md", "LICENSE", "Rakefile", "app/**/*", "lib/**/*", "vendor/assets/**/*"]
   s.authors = ["Sam Pohlenz"]
   s.email = "sam@sampohlenz.com"
   s.homepage = "https://github.com/spohlenz/tinymce-rails"


### PR DESCRIPTION
With the introduction of the github workflow in
a432faf22e86577e69949edb39a37a52763ec458 bundler is run as part of making the gem and this adds bundled code in vendor/bundle.

With the "vendor/**/*" spec in the gemspec file this code also gets included in the gem by accident.