### PR TITLE
Make sure this library works with the new Propshaft manifest format

### DIFF
--- a/gemfiles/rails-7.0-propshaft.gemfile
+++ b/gemfiles/rails-7.0-propshaft.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.0.0'
-gem 'propshaft'
+gem 'propshaft', '< 1.2.0'
 gem 'turbolinks'
 gem 'logger'
 

--- a/gemfiles/rails-7.1-propshaft.gemfile
+++ b/gemfiles/rails-7.1-propshaft.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.1.0'
-gem 'propshaft'
+gem 'propshaft', '< 1.2.0'
 gem 'turbolinks'
 
 group :test do

--- a/gemfiles/rails-7.2-propshaft.gemfile
+++ b/gemfiles/rails-7.2-propshaft.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.2.1'
-gem 'propshaft'
+gem 'propshaft', github: 'rails/propshaft'
 gem 'turbolinks'
 
 group :test do

--- a/gemfiles/rails-8.0-propshaft.gemfile
+++ b/gemfiles/rails-8.0-propshaft.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 8.0.1'
-gem 'propshaft'
+gem 'propshaft', github: 'rails/propshaft'
 gem 'turbolinks'
 
 group :test do

--- a/lib/tinymce/rails/asset_manifest.rb
+++ b/lib/tinymce/rails/asset_manifest.rb
@@ -4,7 +4,8 @@ module TinyMCE
       attr_reader :file
 
       def self.load(manifest_path)
-        PropshaftManifest.try(manifest_path) ||
+        NewPropshaftManifest.try(manifest_path) ||
+          PropshaftManifest.try(manifest_path) ||
           JsonManifest.try(manifest_path, ".sprockets-manifest*.json") ||
           JsonManifest.try(manifest_path, "manifest*.json") ||
           JsonManifest.try(manifest_path) ||
@@ -38,6 +39,7 @@ module TinyMCE
 
     require_relative "asset_manifest/json_manifest"
     require_relative "asset_manifest/null_manifest"
+    require_relative "asset_manifest/new_propshaft_manifest"
     require_relative "asset_manifest/propshaft_manifest"
     require_relative "asset_manifest/yaml_manifest"
   end

--- a/lib/tinymce/rails/asset_manifest/new_propshaft_manifest.rb
+++ b/lib/tinymce/rails/asset_manifest/new_propshaft_manifest.rb
@@ -1,0 +1,49 @@
+module TinyMCE
+  module Rails
+    class NewPropshaftManifest < AssetManifest
+      def self.try(manifest_path)
+        return unless defined?(Propshaft::Manifest)
+        json_file = File.join(manifest_path, ".manifest.json")
+        new(json_file) if File.exist?(json_file)
+      end
+
+      def initialize(file)
+        @file = file
+        @manifest = Propshaft::Manifest.from_path(Pathname.new(file))
+      end
+
+      def append(logical_path, file)
+        entry = Propshaft::Manifest::ManifestEntry.new(
+          logical_path: logical_path,
+          digested_path: logical_path,
+          integrity: nil
+        )
+        @manifest.push(entry)
+      end
+
+      def remove(logical_path)
+        @manifest.delete(logical_path)
+      end
+
+      def remove_digest(logical_path)
+        asset_path(logical_path) do |digested, logical_path|
+          append(logical_path, nil)
+
+          yield digested, logical_path if block_given?
+        end
+      end
+
+      def assets
+        @manifest.transform_values(&:digested_path)
+      end
+
+      def dump
+        @manifest.to_json
+      end
+
+      def write
+        File.open(@file, "wb") { |f| f.write(dump) }
+      end
+    end
+  end
+end

--- a/spec/fixtures/new_propshaft_manifest/.manifest.json
+++ b/spec/fixtures/new_propshaft_manifest/.manifest.json
@@ -1,0 +1,14 @@
+{
+  "application.css": {
+    "digested_path": "application-c2cd8c57.css",
+    "integrity": "sha384-abc123"
+  },
+  "application.js": {
+    "digested_path": "application-bfcdf840.js",
+    "integrity": "sha384-def456"
+  },
+  "tinymce/tinymce.js": {
+    "digested_path": "tinymce/tinymce-52aa7906.js",
+    "integrity": "sha384-uvw012"
+  }
+}

--- a/spec/lib/asset_manifest/new_propshaft_manifest_spec.rb
+++ b/spec/lib/asset_manifest/new_propshaft_manifest_spec.rb
@@ -3,7 +3,7 @@ require "tinymce/rails/asset_manifest"
 
 module TinyMCE
   module Rails
-    describe NewPropshaftManifest do
+    describe NewPropshaftManifest, if: defined?(Propshaft::Manifest) do
       subject(:manifest) { NewPropshaftManifest.new(fixture("new_propshaft_manifest/.manifest.json")) }
 
       def reload_manifest(manifest)
@@ -61,13 +61,13 @@ module TinyMCE
       end
 
       describe ".try" do
-        it "returns a new JsonManifest if a JSON manifest exists for the given path" do
-          manifest = PropshaftManifest.try(fixture("propshaft_manifest"))
-          expect(manifest).to be_an_instance_of(PropshaftManifest)
+        it "returns a NewPropshaftManifest if a new format Propshaft manifest file exists for the given path" do
+          manifest = NewPropshaftManifest.try(fixture("new_propshaft_manifest"))
+          expect(manifest).to be_an_instance_of(NewPropshaftManifest)
         end
 
-        it "returns nil if no JSON manifest was found" do
-          expect(PropshaftManifest.try(fixture("no_manifest"))).to be_nil
+        it "returns nil if no new manifest was found" do
+          expect(NewPropshaftManifest.try(fixture("no_manifest"))).to be_nil
         end
       end
     end

--- a/spec/lib/asset_manifest/new_propshaft_manifest_spec.rb
+++ b/spec/lib/asset_manifest/new_propshaft_manifest_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+require "tinymce/rails/asset_manifest"
+
+module TinyMCE
+  module Rails
+    describe NewPropshaftManifest do
+      subject(:manifest) { NewPropshaftManifest.new(fixture("new_propshaft_manifest/.manifest.json")) }
+
+      def reload_manifest(manifest)
+        JSON.parse(manifest.to_s)
+      end
+
+      it "keeps existing manifest data" do
+        result = reload_manifest(manifest)
+        expect(result["application.css"]).to eq({"digested_path" => "application-c2cd8c57.css", "integrity" => "sha384-abc123"})
+        expect(result["application.js"]).to eq({"digested_path" => "application-bfcdf840.js", "integrity" => "sha384-def456"})
+        expect(result["tinymce/tinymce.js"]).to eq({"digested_path" => "tinymce/tinymce-52aa7906.js", "integrity" => "sha384-uvw012"})
+      end
+
+      describe "#append" do
+        let(:file) { double }
+
+        it "adds files to the manifest without a fingerprint" do
+          manifest.append("tinymce/tinymce.js", file)
+
+          result = reload_manifest(manifest)
+          expect(result["tinymce/tinymce.js"]).to eq({"digested_path" => "tinymce/tinymce.js", "integrity" => nil})
+        end
+      end
+
+      describe "#remove" do
+        it "removes files from the manifest" do
+          manifest.remove("tinymce/tinymce.js")
+
+          result = reload_manifest(manifest)
+          expect(result).to_not have_key("tinymce/tinymce.js")
+        end
+      end
+
+      describe "#remove_digest" do
+        it "sets the file digest value to its non-digested version" do
+          manifest.remove_digest("tinymce/tinymce.js")
+
+          result = reload_manifest(manifest)
+          expect(result["tinymce/tinymce.js"]).to eq({"digested_path" => "tinymce/tinymce.js", "integrity" => nil})
+        end
+
+        it "yields the digested and non-digested file names" do
+          expect { |block|
+            manifest.remove_digest("tinymce/tinymce.js", &block)
+          }.to yield_with_args("tinymce/tinymce-52aa7906.js", "tinymce/tinymce.js")
+        end
+      end
+
+      describe "#each" do
+        it "yields the logical path for each asset that matches the given pattern" do
+          result = []
+          manifest.each(/^tinymce/) { |asset| result << asset }
+          expect(result).to eq(["tinymce/tinymce.js"])
+        end
+      end
+
+      describe ".try" do
+        it "returns a new JsonManifest if a JSON manifest exists for the given path" do
+          manifest = PropshaftManifest.try(fixture("propshaft_manifest"))
+          expect(manifest).to be_an_instance_of(PropshaftManifest)
+        end
+
+        it "returns nil if no JSON manifest was found" do
+          expect(PropshaftManifest.try(fixture("no_manifest"))).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/asset_manifest/propshaft_manifest_spec.rb
+++ b/spec/lib/asset_manifest/propshaft_manifest_spec.rb
@@ -60,12 +60,12 @@ module TinyMCE
       end
 
       describe ".try" do
-        it "returns a new JsonManifest if a JSON manifest exists for the given path" do
+        it "returns a new Propshaft manifest if a Propshaft manifest file exists for the given path" do
           manifest = PropshaftManifest.try(fixture("propshaft_manifest"))
           expect(manifest).to be_an_instance_of(PropshaftManifest)
         end
 
-        it "returns nil if no JSON manifest was found" do
+        it "returns nil if no Propshaft manifest was found" do
           expect(PropshaftManifest.try(fixture("no_manifest"))).to be_nil
         end
       end

--- a/spec/lib/asset_manifest_spec.rb
+++ b/spec/lib/asset_manifest_spec.rb
@@ -4,7 +4,13 @@ module TinyMCE
   module Rails
     describe AssetManifest do
       describe ".load" do
-        it "returns a PropshaftManifest if a Propshaft manifest file exists within the given path" do
+        it "returns a NewPropshaftManifest if a new Propshaft manifest file exists within the given path", if: defined?(Propshaft::Manifest) do
+          manifest = AssetManifest.load(fixture("new_propshaft_manifest"))
+          expect(manifest).to be_an_instance_of(NewPropshaftManifest)
+          expect(manifest.file).to eq fixture("new_propshaft_manifest/.manifest.json")
+        end
+
+        it "returns a PropshaftManifest if a Propshaft manifest file exists within the given path", if: !defined?(Propshaft::Manifest) do
           manifest = AssetManifest.load(fixture("propshaft_manifest"))
           expect(manifest).to be_an_instance_of(PropshaftManifest)
           expect(manifest.file).to eq fixture("propshaft_manifest/.manifest.json")


### PR DESCRIPTION
Since Propshaft 1.2.0, the manifest format has changed to define a list of properties for each logical path. The format of the manifest was never public, but I'm aware that some code were parsing that file and trying to use it. That is why `Propshaft::Manifest` class was added.

This change uses that class instead of parsing the manifest file.